### PR TITLE
Add Bootstrap to Everything

### DIFF
--- a/src/components/assignedDropdown.tsx
+++ b/src/components/assignedDropdown.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "styled-components";
 
 import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';

--- a/src/components/assignedDropdown.tsx
+++ b/src/components/assignedDropdown.tsx
@@ -1,19 +1,13 @@
 import * as React from "react";
 import styled from "styled-components";
 
-const LabelText = styled.label`
-    font-size: 32px;
-    display: block;
-    text-align: center;
-    margin: auto;
-    margin-left: 10px;
-    margin-bottom: 10px;
-`;
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
 
-const Select = styled.select`
-    font-size: 32px;
-    margin: 5px;
-`;
+const font = {
+    fontSize: 32
+};
 
 interface IUser {
     id: number;
@@ -33,12 +27,14 @@ interface IAssignedDropdownProps {
 
 export class AssignedDropdown extends React.Component<IAssignedDropdownProps, IAssignedState> {
     private options: IUser[];
+    private owner: IUser;
 
     constructor(props: IAssignedDropdownProps) {
         super(props);
         this.state = {assignedState: props.assignedState};
 
         this.options = props.sharedUsers;
+        this.owner = props.owner;
 
         this.handleChange = this.handleChange.bind(this);
     }
@@ -47,7 +43,6 @@ export class AssignedDropdown extends React.Component<IAssignedDropdownProps, IA
         const assignedState = this.state.assignedState;
 
         // Maps through the array given and sets up the options
-        // Needs to be done in the render() function or will not produce the proper output
         const arrayOp = this.options.map((item) => {
             return (
                 <option key={item.id} value={item.id}>{item.name}</option>
@@ -55,17 +50,27 @@ export class AssignedDropdown extends React.Component<IAssignedDropdownProps, IA
         });
 
         return(
-            <LabelText>Assigned to:
-                <Select value={assignedState} onChange={this.handleChange}>
-                    <option value={this.props.owner.id}>{this.props.owner.name}</option>
-                    {arrayOp}
-                </Select>
-            </LabelText>
+            <Form>
+                <Form.Group as={Row} controlId="assigneeDropdown">
+                    <Form.Label column sm="5" style={font}>Assigned To:</Form.Label>
+                    <Col sm="7">
+                        <Form.Control
+                            as="select"
+                            onChange={this.handleChange}
+                            defaultValue={assignedState}
+                            size="lg"
+                            style={font}
+                        >
+                            <option value={this.owner.id}>{this.owner.name}</option>
+                            {arrayOp}
+                        </Form.Control>
+                    </Col>
+                </Form.Group>
+            </Form>
         );
     }
 
     // Handles when state is changed
-    // Will still need to add functionality of the option
     private handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
         this.setState({assignedState: e.target.value});
     }

--- a/src/components/newProjectButton.tsx
+++ b/src/components/newProjectButton.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "styled-components";
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';

--- a/src/components/newProjectButton.tsx
+++ b/src/components/newProjectButton.tsx
@@ -1,30 +1,27 @@
 import * as React from "react";
 import styled from "styled-components";
 
-const ProjectButtonBox = styled.button`
-    height: 100px;
-    width: 400px;
-    :hover {
-        cursor: pointer;
-    }
-`;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Button from 'react-bootstrap/Button';
 
-const ButtonText = styled.div`
-    color: black;
-    font-size: 16px;
-`;
+const styles = {
+    button: {
+        width: window.innerWidth,
+        height: 100,
+        fontSize: 32
+    }
+};
 
 export class ProjectButton extends React.Component<{}> {
 
     public render() {
         return (
-            <>
-                <ProjectButtonBox>
-                    <ButtonText>
-                        + New Project
-                    </ButtonText>
-                </ProjectButtonBox>
-            </>
+            <Container fluid>
+                <Row>
+                    <Button style={styles.button} size="lg" variant="outline-primary"> + New Project </Button>
+                </Row>
+            </Container>
         );
     }
 }

--- a/src/components/progressBar.tsx
+++ b/src/components/progressBar.tsx
@@ -10,6 +10,7 @@ const ProgressBar = styled.div`
     border: 1px solid #333;
     position: relative;
     margin: auto;
+    min-width: 300px;
 `;
 
 const SubTaskProgressBar = styled.div`

--- a/src/components/progressBar.tsx
+++ b/src/components/progressBar.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import styled from "styled-components";
 
+import Container from 'react-bootstrap/Container';
+
 const ProgressBar = styled.div`
     height: 130px;
     width: 600px;
@@ -11,10 +13,9 @@ const ProgressBar = styled.div`
 `;
 
 const SubTaskProgressBar = styled.div`
-    height: 105px;
-    width: 395px;
+    height: 90px;
     position: relative;
-    margin: auto;
+    margin: 0;
 `;
 
 const ProgressBarFilling = styled.div`
@@ -63,10 +64,12 @@ export class TaskProgressBar extends React.Component<IProgressBarProps> {
 
         } else {
             return (
-                <ProgressBar>
-                    <ProgressBarFilling percentage={this.props.percentage.toString()} color={color} />
-                    <PercentageText>{this.props.percentage}%</PercentageText>
-                </ProgressBar>
+                <Container>
+                    <ProgressBar>
+                        <ProgressBarFilling percentage={this.props.percentage.toString()} color={color} />
+                        <PercentageText>{this.props.percentage}%</PercentageText>
+                    </ProgressBar>
+                </Container>
             );
         }
     }

--- a/src/components/projectColumn.tsx
+++ b/src/components/projectColumn.tsx
@@ -5,18 +5,19 @@ import { ProjectButton } from "./newProjectButton";
 import { SubTaskButton } from "./subTaskButton";
 import { SubTask } from "./subtaskType";
 
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-  border-width: 5px 5px 0px 5px;
-  border-style: solid;
-  width: 400px;
-  height: ${(props: IColumnProps) => props.height}px;
-`;
+import Container from 'react-bootstrap/Container';
+import Col from 'react-bootstrap/Col';
 
-interface IColumnProps {
-    height: number;
-}
+const styles = {
+    box: {
+        paddingRight: 0,
+        paddingLeft: 0,
+        margin: 0,
+        borderStyle: "solid",
+        borderColor: "gray",
+        height: window.innerHeight
+    }
+};
 
 interface IProjectColumnProps {
     task: SubTask;
@@ -28,41 +29,18 @@ export class ProjectColumn extends React.Component<IProjectColumnProps> {
     constructor(props: IProjectColumnProps) {
         super(props);
 
-        this.state = { height: 0 };
     }
 
     public render() {
-
-        const height = this.checkHeight();
         return (
-            <>
-                <Column height={height} >
+            <Container>
+                <Col style={styles.box} >
                     <ProjectButton />
                     <SubTaskButton name={this.props.task.name} percentage={this.props.task.percentage}
                         key={this.props.task.id} changeHead={this.props.changeHead}
-                        taskHead={this.props.task}></SubTaskButton>;
-                </Column>
-            </>
+                        taskHead={this.props.task}></SubTaskButton>
+                </Col>
+            </Container>
         );
-    }
-
-    // When this object is displayed, add an event that check for window resizes.
-    public componentDidMount() {
-        window.addEventListener("resize", this.updateDimensions);
-    }
-
-    // Remove event when the object is unmounted.
-    public componentWillUnmount() {
-        window.removeEventListener("resize", this.updateDimensions);
-    }
-
-    private updateDimensions = () => {
-        this.setState({ height: window.innerHeight });
-    }
-
-    // Make sure column doesn"t get too small
-    private checkHeight = () => {
-        const height = window.innerHeight;
-        return height > 825 ? height : 825;
     }
 }

--- a/src/components/projectColumn.tsx
+++ b/src/components/projectColumn.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import styled from "styled-components";
 
 import { ProjectButton } from "./newProjectButton";
 import { SubTaskButton } from "./subTaskButton";
@@ -15,7 +14,8 @@ const styles = {
         margin: 0,
         borderStyle: "solid",
         borderColor: "gray",
-        height: window.innerHeight
+        height: window.innerHeight,
+        minWidth: 250
     }
 };
 

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -2,17 +2,18 @@
 import * as React from "react";
 import styled from "styled-components";
 
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
 import { ProjectColumn } from "./projectColumn";
 import { SubTaskColumn } from "./subTaskColumn";
 import { SubTask } from "./subtaskType";
 import { TaskView } from "./taskView";
 
-const Container = styled.div`
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  display: flex;
-  flex-direction: row;
+const containerStyle = styled.div`
+    padding-left: 0;
+    padding-right: 0;
 `;
 
 interface IUser {
@@ -134,21 +135,23 @@ export class ProjectPage extends React.Component<{}, { projectHead: SubTask, pro
   // but should be replaced.
   public render() {
     return (
-      <Container>
-        <ProjectColumn task={this.state.projectHead} changeHead={this.changeHead} />
-        <TaskView
-          name={this.state.projectData.name}
-          completion={this.state.projectData.percentage}
-          description={this.state.projectData.description}
-          dueDate={this.state.projectData.dueDate}
-          startDate={this.state.projectData.startDate}
-          status={this.state.projectData.status}
-          assignee={this.state.projectData.assignee}
-          tags={this.state.projectData.tags}
-          owner={this.state.projectData.owner}
-          sharedUsers={this.state.projectData.sharedWith}
-        />
-        <SubTaskColumn subtasks={this.state.projectData.subtasks} changeHead={this.changeHead}></SubTaskColumn>
+      <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
+        <Row noGutters={true}>
+            <Col sm="3"><ProjectColumn task={this.state.projectHead} changeHead={this.changeHead} /></Col>
+            <Col sm="6"><TaskView
+              name={this.state.projectData.name}
+              completion={this.state.projectData.percentage}
+              description={this.state.projectData.description}
+              dueDate={this.state.projectData.dueDate}
+              startDate={this.state.projectData.startDate}
+              status={this.state.projectData.status}
+              assignee={this.state.projectData.assignee}
+              tags={this.state.projectData.tags}
+              owner={this.state.projectData.owner}
+              sharedUsers={this.state.projectData.sharedWith}
+            /></Col>
+            <Col sm="3"><SubTaskColumn subtasks={this.state.projectData.subtasks} changeHead={this.changeHead}></SubTaskColumn></Col>
+        </Row>
       </Container>
     );
   }

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -1,6 +1,4 @@
-
 import * as React from "react";
-import styled from "styled-components";
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -11,10 +9,13 @@ import { SubTaskColumn } from "./subTaskColumn";
 import { SubTask } from "./subtaskType";
 import { TaskView } from "./taskView";
 
-const containerStyle = styled.div`
-    padding-left: 0;
-    padding-right: 0;
-`;
+const styles = {
+    box: {
+        paddingLeft: 0,
+        paddingRight: 0,
+        minWidth: 1300
+    }
+};
 
 interface IUser {
   id: number;
@@ -135,7 +136,7 @@ export class ProjectPage extends React.Component<{}, { projectHead: SubTask, pro
   // but should be replaced.
   public render() {
     return (
-      <Container fluid style={{ paddingLeft: 0, paddingRight: 0 }}>
+      <Container fluid style={styles.box}>
         <Row noGutters={true}>
             <Col sm="3"><ProjectColumn task={this.state.projectHead} changeHead={this.changeHead} /></Col>
             <Col sm="6"><TaskView

--- a/src/components/shareUsers.tsx
+++ b/src/components/shareUsers.tsx
@@ -1,47 +1,26 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-const SharedWithTab = styled.div`
-    display: flex;
-    flex-direction: row;
-    border: solid 2px black;
-    border-top: none;
-    width: 100%;
-`;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import ListGroup from 'react-bootstrap/ListGroup';
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
 
-const UserText = styled.div`
-    font-size: 32px;
-`;
-
-const OwnerBox = styled.div`
-    border-right: solid 1px black;
-    display: flex;
-    flex-direction: column;
-    padding: 5px;
-    width: 80px;
-`;
-
-const SharedUserBox = styled.div`
-    display: flex;
-    flex-direction: column;
-    padding: 5px;
-    margin-left: 10px;
-`;
-
-const LabelText = styled.label`
-    font-size: 24px;
-    margin-right: 11px;
-`;
-
-const ButtonText = styled.div`
-    font-size: 32px;
-`;
-
-const AddUserButton = styled.button`
-    border-radius: 100%;
-    width: 50px;
-    height: 50px;
-`;
+const styles = {
+    owner: {
+        fontSize: 24,
+        width: 110
+    },
+    sharedW: {
+        fontSize: 24,
+        width: 175
+    },
+    user: {
+        fontSize: 24,
+        width: 110
+    }
+};
 
 interface User {
     id: number;
@@ -66,24 +45,29 @@ export class ShareUsers extends React.Component<ShareUserProps> {
     render() {
         const sharedArray = this.sharedUsers.map((item) => {
             return (
-                <SharedUserBox key={item.id}> <UserText> {item.name} </UserText> </SharedUserBox>
+                <Button key={item.id} style={styles.user} variant="outline-secondary">{item.name}</Button>
             )
         });
 
         return (
-                <SharedWithTab>
-                    <OwnerBox>
-                        <LabelText> Owner </LabelText>
-                        <UserText> {this.owner.name} </UserText>
-                    </OwnerBox>
-                    <SharedUserBox>
-                        <LabelText> Shared With </LabelText>
-                    </SharedUserBox>
-                    {sharedArray}
-                    <AddUserButton>
-                        <ButtonText> + </ButtonText>
-                    </AddUserButton>
-                </SharedWithTab>
+            <Container>
+                <Row noGutters={true}>
+                    <ListGroup horizontal>
+                        <ListGroup>
+                            <ListGroup.Item style={styles.owner}>Owner</ListGroup.Item>
+                            <Button style={styles.owner} variant="outline-secondary">{this.owner.name}</Button>
+                        </ListGroup>
+                        <ListGroup>
+                            <ListGroup.Item style={styles.sharedW}>Shared with</ListGroup.Item>
+                            <ListGroup horizontal>
+                                <ButtonGroup>
+                                    {sharedArray}
+                                </ButtonGroup>
+                            </ListGroup>
+                        </ListGroup>
+                    </ListGroup>
+                </Row>
+            </Container>
         )
     }
 }

--- a/src/components/shareUsers.tsx
+++ b/src/components/shareUsers.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from 'styled-components';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -19,6 +18,9 @@ const styles = {
     user: {
         fontSize: 24,
         width: 110
+    },
+    box: {
+        minWidth: 100
     }
 };
 
@@ -50,7 +52,7 @@ export class ShareUsers extends React.Component<ShareUserProps> {
         });
 
         return (
-            <Container>
+            <Container style={styles.box}>
                 <Row noGutters={true}>
                     <ListGroup horizontal>
                         <ListGroup>

--- a/src/components/statusDropdown.tsx
+++ b/src/components/statusDropdown.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from 'styled-components';
 
 import Form from 'react-bootstrap/Form';
 import Row from 'react-bootstrap/Row';

--- a/src/components/statusDropdown.tsx
+++ b/src/components/statusDropdown.tsx
@@ -1,19 +1,13 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-const LabelText = styled.label`
-    font-size: 32px;
-    display: block;
-    text-align: center;
-    margin: auto;
-    margin-right: 10px;
-    margin-bottom: 10px;
-`;
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
 
-const Select = styled.select`
-    font-size: 32px;
-    margin: 5px;
-`;
+const font = {
+    fontSize: 32
+};
 
 interface Options {
     id: number;
@@ -29,7 +23,6 @@ interface StatusState {
 interface StatusDropdownProps {
     taskStatus: string;
     statusList: Options[];
-
 }
 
 export class StatusDropdown extends React.Component<StatusDropdownProps, StatusState> {
@@ -54,7 +47,6 @@ export class StatusDropdown extends React.Component<StatusDropdownProps, StatusS
         const taskStatus = this.state.taskStatus;
 
         // Maps through the array given and sets up the options
-        // Needs to be done in the render() function or will not produce the proper output
         const arrayOp = this.options.map((item, i) => {
             return (
                 <option key={item.id} value={item.value}>{item.label}</option>
@@ -62,11 +54,22 @@ export class StatusDropdown extends React.Component<StatusDropdownProps, StatusS
         });
 
         return(
-            <LabelText>Status:
-                <Select value={taskStatus} onChange={this.handleChange}>
-                    {arrayOp}
-                </Select>
-            </LabelText>
+            <Form style={font}>
+                <Form.Group as={Row} controlId="statusDropdown">
+                    <Form.Label column sm="4">Status:</Form.Label>
+                    <Col sm="8">
+                        <Form.Control
+                            as="select"
+                            onChange={this.handleChange}
+                            defaultValue={taskStatus}
+                            size="lg"
+                            style={font}
+                        >
+                            {arrayOp}
+                        </Form.Control>
+                    </Col>
+                </Form.Group>
+            </Form>
         )
     }
 }

--- a/src/components/subTaskButton.tsx
+++ b/src/components/subTaskButton.tsx
@@ -1,27 +1,33 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Button from 'react-bootstrap/Button';
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
 import { TaskProgressBar } from './progressBar';
 import { SubTask } from './subtaskType';
 
-// With the percentage bars there, it might not be apparent that they are buttons.
-// With a hover state, we can make that clear by changing the mouse pointer to the pointer hand.
-const TaskButton = styled.button`
-    height: 110px;
-    width: 400px;
-    padding: 0px;
-    position: relative;
-    :hover {
-        cursor: pointer;
+const styles = {
+    button: {
+        width: window.innerWidth,
+        height: 100,
+        fontSize: 32,
+        padding: 0,
+        margin: 0
+    },
+    progress: {
+        height: 100
     }
-`;
+};
 
 const SubTaskName = styled.div`
     font-size: 32px;
     position: absolute;
     z-index: 99;
-    top: 30px;
-    left: 30px;
+    left: 100px;
+    margin-top: 15px;
 `;
 
 interface SubTaskButtonProps {
@@ -59,10 +65,14 @@ export class SubTaskButton extends React.Component<SubTaskButtonProps>{
     render() {
         this.checkNameLength();
         return (
-            <TaskButton onClick={this.onButtonClick}>
-                <SubTaskName>{this.displayedName}</SubTaskName>
-                <TaskProgressBar percentage={this.props.percentage} isTaskButton={true}></TaskProgressBar>
-            </TaskButton>
+            <Container>
+                <Row>
+                    <Button style={styles.button} onClick={this.onButtonClick} variant="outline-dark">
+                        <SubTaskName>{this.displayedName}</SubTaskName>
+                        <TaskProgressBar percentage={this.props.percentage} isTaskButton={true}></TaskProgressBar>
+                    </Button>
+                </Row>
+            </Container>
         );
     }
 };

--- a/src/components/subTaskButton.tsx
+++ b/src/components/subTaskButton.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Button from 'react-bootstrap/Button';
-import ProgressBar from 'react-bootstrap/ProgressBar';
 
 import { TaskProgressBar } from './progressBar';
 import { SubTask } from './subtaskType';
@@ -26,8 +25,9 @@ const SubTaskName = styled.div`
     font-size: 32px;
     position: absolute;
     z-index: 99;
-    left: 100px;
+    left: 25px;
     margin-top: 15px;
+    min-width: 225px;
 `;
 
 interface SubTaskButtonProps {
@@ -52,8 +52,8 @@ export class SubTaskButton extends React.Component<SubTaskButtonProps>{
 
     // If the title is too long, we should shorten it to fit the space we have.
     checkNameLength = () => {
-        if (this.name.length > 16) {
-            this.displayedName = this.name.substring(0, 15);
+        if (this.name.length > 9) {
+            this.displayedName = this.name.substring(0, 8);
             this.displayedName += "...";
         }
     }

--- a/src/components/subTaskColumn.tsx
+++ b/src/components/subTaskColumn.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+
 import { SubTaskButton } from './subTaskButton';
 import { SubTask } from './subtaskType';
-import { Button } from 'react-bootstrap';
 
-interface ColumnProps {
-    height: number;
-};
-
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-  border-width: 5px 5px 5px 0px;
-  border-style: solid;
-  height: ${(props: ColumnProps) => props.height}px;
-`;
-
-const NewTaskButton = styled.button`
-    height: 100px;
-    width: 400px;
-    :hover {
-        cursor: pointer;
+const styles = {
+    button: {
+        width: window.innerWidth,
+        height: 100,
+        fontSize: 32
+    },
+    box: {
+        paddingRight: 0,
+        paddingLeft: 0,
+        margin: 0,
+        borderStyle: "solid",
+        borderColor: "gray",
+        height: window.innerHeight
     }
-`;
+};
 
 interface SubTaskColumnProps {
     subtasks: SubTask[];
@@ -36,39 +36,22 @@ export class SubTaskColumn extends React.Component<SubTaskColumnProps>{
 
     constructor(props: SubTaskColumnProps) {
         super(props);
-
-        this.state = { height: 0 };
-    }
-
-    updateDimensions = () => {
-        this.setState({ height: window.innerHeight });
-    };
-
-    // When this object is displayed, add an event that check for window resizes.
-    componentDidMount() {
-        window.addEventListener('resize', this.updateDimensions);
-    }
-
-    // Remove event when the object is unmounted.
-    componentWillUnmount() {
-        window.removeEventListener('resize', this.updateDimensions);
-    }
-
-    // Make sure column doesn't get too small
-    checkHeight = () => {
-        const height = window.innerHeight;
-        return height > 825 ? height : 825;
     }
 
     render() {
-        const height = this.checkHeight();
         return (
-            <Column height = {height}>
-                <Button>+ New Task</Button>
-                {this.props.subtasks.map((task) => {
-                    return <SubTaskButton name={task.name} percentage={task.percentage} key={task.id} changeHead={this.props.changeHead} taskHead={task}></SubTaskButton>;
-                })}
-            </Column>
+            <Container>
+                <Col style={styles.box}>
+                    <Row noGutters={true}>
+                        <Button style={styles.button} size="lg" variant="outline-primary"> + New Task </Button>
+                    </Row>
+                    <Row noGutters={true}>
+                        {this.props.subtasks.map((task) => {
+                            return <SubTaskButton name={task.name} percentage={task.percentage} key={task.id} changeHead={this.props.changeHead} taskHead={task}></SubTaskButton>;
+                        })}
+                    </Row>
+                </Col>
+            </Container>
         );
     }
 };

--- a/src/components/subTaskColumn.tsx
+++ b/src/components/subTaskColumn.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from 'styled-components';
 
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
@@ -21,7 +20,8 @@ const styles = {
         margin: 0,
         borderStyle: "solid",
         borderColor: "gray",
-        height: window.innerHeight
+        height: window.innerHeight,
+        minWidth: 200
     }
 };
 

--- a/src/components/taskTags.tsx
+++ b/src/components/taskTags.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import styled from 'styled-components';
 
-import ListGroup from 'react-bootstrap/ListGroup';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 

--- a/src/components/taskTags.tsx
+++ b/src/components/taskTags.tsx
@@ -1,35 +1,18 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-const Tags = styled.div`
-    text-align: center;
-    margin: 10px;
-`;
+import ListGroup from 'react-bootstrap/ListGroup';
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
 
-const LabelText = styled.label`
-    font-size: 32px;
-`;
-
-// Have a visual signifier that a user could remove a tag if they wanted to
-// when they click on it
-const TagButton = styled.button`
-    border: none;
-    margin: 5px;
-    :hover {
-        cursor: pointer;
-        text-decoration: line-through;
+const styles = {
+    tagBox: {
+        margin: "auto"
+    },
+    tagText: {
+        fontSize: 24
     }
-`;
-
-const ButtonText = styled.div`
-    font-size: 32px;
-`;
-
-const AddTagButton = styled.button`
-    border-radius: 100%;
-    width: 50px;
-    height: 50px;
-`;
+};
 
 interface Tag {
     tag: string;
@@ -53,16 +36,15 @@ export class TaskTags extends React.Component<TaskTagsProps> {
         const tagArray = this.tags.map((item , i) =>
         {
             return (
-                <TagButton key={item.id}> <ButtonText> {item.tag} </ButtonText> </TagButton>
+                <Button key={item.id} variant="outline-secondary" style={styles.tagText}> {item.tag}</Button>
             )
         });
 
         return(
-            <Tags>
-                <LabelText> Tags: </LabelText>
+            <ButtonGroup style={styles.tagBox}>
                 {tagArray}
-                <AddTagButton><ButtonText>+</ButtonText></AddTagButton>
-            </Tags>
+                <Button variant="outline-secondary" style={styles.tagText}> + </Button>
+            </ButtonGroup>
         )
     }
 }

--- a/src/components/taskView.tsx
+++ b/src/components/taskView.tsx
@@ -4,116 +4,77 @@ import styled from 'styled-components';
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+
 import { TaskProgressBar } from './progressBar';
 import { StatusDropdown } from './statusDropdown';
 import { AssignedDropdown } from './assignedDropdown';
 import { TaskTags } from './taskTags';
 import { ShareUsers } from './shareUsers';
 
-interface ColumnProps {
-    height: number;
-};
-
-// The column will remain at its maximum height, so if the window
-// is shrunk , a scrollbar will remain unless the height of the column
-// is changed to the window height
-const Column = styled.div`
-    display: flex;
-    flex-direction: column;
-    height: ${(props: ColumnProps) => props.height}px;
-`;
-
-interface ContainerProps {
-    height: number;
-    width: number;
-};
-
-const Container = styled.div`
-    border-width: 5px;
-    border-style: solid;
-    padding: 50px;
-    height: ${(props: ContainerProps) => props.height}px;
-    width: ${(props: ContainerProps) => props.width}px;
-`;
+const styles = {
+    font: {
+        fontSize: 32
+    },
+    desc: {
+        fontSize: 24,
+        marginTop: 10,
+        marginBottom: 10,
+        maxHeight: 225
+    },
+    container: {
+        paddingLeft: 0,
+        paddingRight: 0
+    },
+    row: {
+        paddingTop:50
+    },
+    saveButton: {
+        height: 100,
+        width: 160,
+        fontSize: 32
+    },
+    deleteButton: {
+        marginTop: 50,
+        fontSize: 32
+    },
+    datePick: {
+        fontSize: 32,
+        margin: "auto",
+        marginTop: 10
+    },
+    sharedTab: {
+        bottom: 0,
+        left: 0,
+        margin: 0,
+        borderColor: "gray",
+        borderStyle: "solid",
+        width: 750,
+        padding: 0
+    },
+    historyButton: {
+        marginTop: 0,
+        height: 150,
+        width: 160
+    }
+}
 
 const Title = styled.div`
     font-size: 72px;
     margin-left: 50px;
-    margin-top: 10px;
-`;
-
-const SaveButton = styled.button`
-    width: 177px;
-    height: 100px;
-`;
-
-const SaveButtonText = styled.div`
-    font-size: 32px;
-    margin: 30px;
-`;
-
-// The delete button is absolutely positioned to the right because the length of the
-// title could influence the button's position.
-const DeleteButton = styled.button`
-    width: 177px;
-    height: 40px;
-    position: absolute;
-    top: 60px;
-    right: 30px;
-`;
-
-const DeleteButtonText = styled.div`
-    font-size: 32px;
+    text-align: center;
 `;
 
 const LabelText = styled.div`
     font-size: 32px;
     text-align: center;
-    margin-bottom: 10px;
-`;
-
-const DueDates = styled.div`
-    font-size: 32px;
-    text-align: center;
-    margin-bottom: 10px;
-	margin-left: 30%;
-	margin-right: auto;
-`;
-
-const CalendarButton = styled.button`
-    width: 180px;
-    height: 50px;
-    margin: 5px;
-`;
-
-// In order to format the description on the page properly, needed to create a seperate div for it
-const DescBox = styled.div`
-    display: flex;
-    flex-direction: row;
-    position: relative;
-    left: 175px;
-    margin-top: 10px;
-`;
-
-const DescText = styled.textarea`
-    font-size: 32px;
     margin: auto;
-    margin-left: 10px;
-    max-width: 600px;
-    max-height: 150px;
-`;
-
-const HistoryButton = styled.button`
-    width: 207px;
-    height: 125px;
-    bottom: 3px;
-    right: 408px;
-`;
-
-const Row = styled.div`
-    display: flex;
-    flex-direction: row;
-    position: relative;
+    margin-bottom: 15px;
+    width: 175px;
 `;
 
 interface Options {
@@ -160,9 +121,9 @@ export class TaskView extends React.Component<TaskViewProps>{
     tags: Tag[];
     owner: User;
     sharedUsers: User[];
-	
+
 	state = {width: 0, height: 0, dueDate: this.props.dueDate};
-	
+
 
     constructor(props: TaskViewProps) {
         super(props);
@@ -188,19 +149,19 @@ export class TaskView extends React.Component<TaskViewProps>{
 
         this.state = { width: 0, height: 0, dueDate: this.props.dueDate};
     }
-	
+
 	handleChange = (date: Date) => {
 		this.setState({
 			dueDate: date
 		});
 		this.calculateDaysLeft();
 	};
-  
+
     // If the title is too long, we should shorten it to fit the space we have.
     displayName = () => {
         let displayedName = this.props.name;
-        if (displayedName.length > 16) {
-            displayedName = displayedName.substring(0, 15);
+        if (displayedName.length > 13) {
+            displayedName = displayedName.substring(0, 13);
             displayedName += "...";
         }
         return displayedName;
@@ -260,36 +221,6 @@ export class TaskView extends React.Component<TaskViewProps>{
         }
     }
 
-    updateDimensions = () => {
-        this.setState({ width: window.innerWidth, height: window.innerHeight });
-    };
-
-    // When this object is displayed, add an event that check for window resizes.
-    componentDidMount() {
-        window.addEventListener('resize', this.updateDimensions);
-    }
-
-    // Remove event when the object is unmounted.
-    componentWillUnmount() {
-        window.removeEventListener('resize', this.updateDimensions);
-    }
-
-    // Return the height the taskView Container should display at.
-    // Prevents the taskView from getting too small.
-    checkHeight = () => {
-        const shareUsersHeight = 208;
-        const height = window.innerHeight - shareUsersHeight;
-        return height > 620 ? height : 620;
-    }
-
-    // Return the width the taskView Container should display at.
-    // Prevents the taskView from getting too small.
-    checkWidth = () => {
-        const totalSidebarWidth = 930;
-        const width = window.innerWidth - totalSidebarWidth;
-        return width > 920 ? width : 920;
-    }
-
     // TODO
     // When the database is integrated, we need to implement the onChange here so that
     // the new text is saved in some way and inserted into the database.
@@ -300,55 +231,87 @@ export class TaskView extends React.Component<TaskViewProps>{
         this.startDateString();
         this.daysLeftCheck();
         const name = this.displayName();
-        const height = this.checkHeight();
-        const width = this.checkWidth();
         const description = this.props.description;
         return (
-            <Column height={window.innerHeight}>
-                <Container height={height} width={width}>
-                    <Row>
-                        <SaveButton>
-                            <SaveButtonText>Save</SaveButtonText>
-                        </SaveButton>
-                        <Title>{name}</Title>
-                        <DeleteButton>
-                            <DeleteButtonText>Delete</DeleteButtonText>
-                        </DeleteButton>
-                    </Row>
-                    <TaskProgressBar percentage={this.props.completion} />
-                    <DueDates>
-					<Row>Due Date:
-							<DatePicker
-								selected={this.state.dueDate}
-								onChange={this.handleChange}
-							/>
-						</Row>
-                    </DueDates>
-                    <LabelText> {this.displayedDaysLeft} </LabelText>
-                    <Row>
-                        <StatusDropdown taskStatus={this.status} statusList={this.statusOptions} />
-                        <AssignedDropdown assignedState={this.props.assignee} sharedUsers={this.sharedUsers} owner={this.owner} />
-                    </Row>
-                    <LabelText> Date Started: {this.displayedStartDate} </LabelText>
-                    <LabelText> Average Time Per Task: N/A Days </LabelText>
-                    <Row>
-                        <DescBox>
-                            <LabelText> Description: </LabelText>
-                            <DescText value={description} onChange={e => null} />
-                        </DescBox>
-                    </Row>
-                    <TaskTags tags={this.tags} />
-
-                </Container>
-                <Row>
-                    <ShareUsers owner={this.owner} sharedUsers={this.sharedUsers} />
-                    <HistoryButton>
-                        <LabelText>
-                            History
-                    </LabelText>
-                    </HistoryButton>
+            <Container style={styles.container}>
+                <Row style={styles.row} noGutters={true}>
+                    <Col md="2" >
+                        <Button
+                            variant="outline-success"
+                            size='lg'
+                            block
+                            style={styles.saveButton}
+                        >
+                            Save
+                        </Button>
+                    </Col>
+                    <Col md="8"> <Title>{name}</Title> </Col>
+                    <Col md="2">
+                        <Button
+                            variant="outline-danger"
+                            size='lg'
+                            block
+                            style={styles.deleteButton}
+                        >
+                            Delete
+                        </Button>
+                    </Col>
                 </Row>
-            </Column>
+                <Row noGutters={true}>
+                    <TaskProgressBar percentage={this.props.completion} />
+                </Row>
+                <Row noGutters={true}>
+                    <Form style={styles.datePick}>
+                        <Form.Group as={Row} noGutters={true}>
+                            <Form.Label column sm="4">Due Date: </Form.Label>
+                            <Col sm="8">
+                                <Form.Text style={styles.font}>
+                                    <DatePicker
+                                        selected={this.state.dueDate}
+                                        onChange={this.handleChange}
+                                    />
+                                </Form.Text>
+                            </Col>
+                        </Form.Group>
+                    </Form>
+                </Row>
+                <Row noGutters={true}>
+                    <LabelText> {this.displayedDaysLeft} </LabelText>
+                </Row>
+                <Row>
+                    <Col md="5"> <StatusDropdown taskStatus={this.status} statusList={this.statusOptions} /> </Col>
+                    <Col md="7"><AssignedDropdown assignedState={this.props.assignee} sharedUsers={this.sharedUsers} owner={this.owner} /> </Col>
+                </Row>
+                <Row noGutters={true}>
+                    <Form style={styles.desc}>
+                        <Form.Group as={Row} noGutters={true}>
+                            <Form.Label column sm="2"> Description: </Form.Label>
+                            <Col sm="10">
+                                <Form.Control
+                                    as="textarea"
+                                    rows="4"
+                                    cols="55"
+                                    defaultValue={description}
+                                    onChange={e => null}
+                                    style={styles.desc}
+                                />
+                            </Col>
+                        </Form.Group>
+                    </Form>
+                </Row>
+                <Row noGutters={true}>
+                    <Col md="10" style={styles.sharedTab}> <ShareUsers owner={this.owner} sharedUsers={this.sharedUsers} /> </Col>
+                    <Col md="2">
+                        <Button
+                            variant = "outline-info"
+                            size = "lg"
+                            block
+                            style={styles.historyButton}>
+                            History
+                        </Button>
+                    </Col>
+                </Row>
+            </Container>
         );
     }
 };

--- a/src/components/taskView.tsx
+++ b/src/components/taskView.tsx
@@ -28,10 +28,12 @@ const styles = {
     },
     container: {
         paddingLeft: 0,
-        paddingRight: 0
+        paddingRight: 0,
+        minWidth: 650
     },
     row: {
-        paddingTop:50
+        paddingTop:50,
+        minWidth: 300
     },
     saveButton: {
         height: 100,
@@ -50,16 +52,14 @@ const styles = {
     sharedTab: {
         bottom: 0,
         left: 0,
-        margin: 0,
         borderColor: "gray",
         borderStyle: "solid",
-        width: 750,
         padding: 0
     },
     historyButton: {
-        marginTop: 0,
         height: 150,
-        width: 160
+        width: 160,
+        fontSize: 32
     }
 }
 
@@ -67,6 +67,7 @@ const Title = styled.div`
     font-size: 72px;
     margin-left: 50px;
     text-align: center;
+    min-width: 200px;
 `;
 
 const LabelText = styled.div`
@@ -300,7 +301,7 @@ export class TaskView extends React.Component<TaskViewProps>{
                     </Form>
                 </Row>
                 <Row noGutters={true}>
-                    <Col md="10" style={styles.sharedTab}> <ShareUsers owner={this.owner} sharedUsers={this.sharedUsers} /> </Col>
+                    <Col md="9" style={styles.sharedTab}> <ShareUsers owner={this.owner} sharedUsers={this.sharedUsers} /> </Col>
                     <Col md="2">
                         <Button
                             variant = "outline-info"


### PR DESCRIPTION
I turned everything into Bootstrap and did some other styling as well! From here on out if you do anything with the front end, make sure to use Bootstrap because the process of making it all Bootstrap after the fact is really annoying! 

With the extra styling, I was unable to get it working with styled-components. This wasn't too bad, as I had to remove most of it as I was replacing it with Bootstrap stuff, and in some cases I left the styled-components as they still worked and it's not like I had to replace them. 

I didn't style Everything completely out, as I wanted to focus just changing everything over to Bootstrap first. There's likely some small things we can add(like while saving to show that it's in progress, and other things), but I figure those can likely be added as things get integrated to make it easier. Obviously this can look much better, but after working on this for a while, I feel like as far as the initially integrating for Bootstrap, that it works. I tried to get rid of all the gutters, but in some cases it wouldn't leave, and I can only style things for so long until I'm hitting a brick wall, and I think I'm there. I'll probably go through and do more styling once I move onto the accessibility options, as they'll need to be more or so finalized by that point, and it'll have been enough time for me to do that. 

I got rid of things like the Tags, Date Started, and Average Time for Tasks. This made the main task page less cluttered, and that information could be listed elsewhere(Date Started)/put back on the page if we have time to implement them(Tags). The tags component is still there, though not on the main task page anymore in case we want to add it later.

Also, while Bootstrap has a separate thing for progress bars, I didn't change any of them because it's annoying to change color, and as far as formatting goes, it doesn't change much from what we already have, so I just kept it to be the same from what was already implemented.

![image](https://user-images.githubusercontent.com/56561909/78054008-67d75f80-734f-11ea-9555-5531880a9b47.png)