### PR TITLE
Create New Projects and New Tasks

### DIFF
--- a/src/components/landProjCol.tsx
+++ b/src/components/landProjCol.tsx
@@ -44,7 +44,7 @@ export class LandProjectColumn extends React.Component<LandProjectColumnProps, {
     // change, a componentDidUpdate() function will need to be added so that
     // the query can be re-run
     getProjects = () => {
-        fetch("https://tasktabs-backend.herokuapp.com/api/projects")
+        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/projects`)
         .then(res => res.json())
         .then(
             (result) => {
@@ -81,7 +81,7 @@ export class LandProjectColumn extends React.Component<LandProjectColumnProps, {
             return (
                 <Container>
                     <Col style={styles.box} >
-                        <ProjectButton />
+                        <ProjectButton changeHead={this.props.selectProject}/>
                         {projects.map((task) => {
                             return <SubTaskButton name={task.title} changeHead={this.props.selectProject} percentage={task.progress} key={task._id} taskHead={task._id}></SubTaskButton>;
                         })}

--- a/src/components/navBar.tsx
+++ b/src/components/navBar.tsx
@@ -87,7 +87,7 @@ export class NavBar extends React.Component<INavBarProps, NavBarState> {
                                 data-onsuccess="onSignIn"
                                 data-height="48"
                                 data-width="162"
-                                data-borderStyle="none">
+                                >
                                 Google
                             </Container>
                         </Nav>

--- a/src/components/newProjectButton.tsx
+++ b/src/components/newProjectButton.tsx
@@ -26,7 +26,9 @@ export class ProjectButton extends React.Component<ProjectButtonProps> {
 
     createNewProject = () => {
 
-        const newProject = {title:"New project", status:"Active", progress:0};
+        // TODO 
+        // should be user from google oauth
+        const newProject = {owner: "littlebobbytables@xkcd.com", title:"New project", status:"Active", progress:0};
         fetch(`${ApplicationConfig.api.staging.baseUrl}/api/projects`,
         {
             method: 'POST',

--- a/src/components/newProjectButton.tsx
+++ b/src/components/newProjectButton.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Button from 'react-bootstrap/Button';
+import ApplicationConfig from './applicationConfig';
 
 const styles = {
     button: {
@@ -12,13 +13,43 @@ const styles = {
     }
 };
 
-export class ProjectButton extends React.Component<{}> {
+interface ProjectButtonProps {
+    changeHead: (newHead: number) => any;
+}
+
+export class ProjectButton extends React.Component<ProjectButtonProps> {
+
+    constructor(props: ProjectButtonProps) {
+        super(props);
+
+    }
+
+    createNewProject = () => {
+
+        const newProject = {title:"New project", status:"Active", progress:0};
+        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/projects`,
+        {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+                'Content-Type': 'application/json'
+              },
+            body: JSON.stringify(newProject)
+        }).then((response) => response.json())
+            .then((data) => {
+                // This will refresh the page with the new project as the current head.
+                this.props.changeHead(data._id);
+          })
+          .catch((error) => {
+            console.error('Error:', error);
+          });
+    }
 
     public render() {
         return (
             <Container fluid>
                 <Row>
-                    <Button style={styles.button} size="lg" variant="outline-primary"> + New Project </Button>
+                    <Button style={styles.button} size="lg" variant="outline-primary" onClick={this.createNewProject}> + New Project </Button>
                 </Row>
             </Container>
         );

--- a/src/components/newSubTaskButton.tsx
+++ b/src/components/newSubTaskButton.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Button from 'react-bootstrap/Button';
+import ApplicationConfig from './applicationConfig';
+
+const styles = {
+    button: {
+        width: window.innerWidth,
+        height: 100,
+        fontSize: 32
+    }
+};
+
+interface NewSubTaskButtonProps {
+    head: number,
+    changeHead: (newHead: number) => any;
+}
+
+export class NewSubTaskButton extends React.Component<NewSubTaskButtonProps> {
+
+    constructor(props: NewSubTaskButtonProps) {
+        super(props);
+
+    }
+
+    createNewSubTask = () => {
+
+        const newSubTask = {parentId: this.props.head, title:"New task", status:"Active", progress:0};
+        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks`,
+        {
+            method: 'POST',
+            mode: 'cors',
+            headers: {
+                'Content-Type': 'application/json'
+              },
+            body: JSON.stringify(newSubTask)
+        }).then((response) => response.json())
+            .then((data) => {
+                // This will refresh the page with the new task as the current head.
+                this.props.changeHead(data._id);
+          })
+          .catch((error) => {
+            console.error('Error:', error);
+          });
+    }
+
+    public render() {
+        return (
+            <Container fluid>
+                <Row>
+                    <Button style={styles.button} size="lg" variant="outline-primary" onClick={this.createNewSubTask}> + New Task </Button>
+                </Row>
+            </Container>
+        );
+    }
+}

--- a/src/components/newSubTaskButton.tsx
+++ b/src/components/newSubTaskButton.tsx
@@ -27,7 +27,9 @@ export class NewSubTaskButton extends React.Component<NewSubTaskButtonProps> {
 
     createNewSubTask = () => {
 
-        const newSubTask = {parentId: this.props.head, title:"New task", status:"Active", progress:0};
+        // TODO 
+        // should be user from google oauth
+        const newSubTask = {owner: "littlebobbytables@xkcd.com", parentId: this.props.head, title:"New task", status:"Active", progress:0};
         fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks`,
         {
             method: 'POST',

--- a/src/components/projectColumn.tsx
+++ b/src/components/projectColumn.tsx
@@ -47,6 +47,7 @@ export class ProjectColumn extends React.Component<ProjectColumnProps, {error: a
     componentDidUpdate() {
         if(this.props.head !== this.head) {
             this.head = this.props.head;
+            this.setState({isLoaded: false});
             this.getProjects();
         }
     }

--- a/src/components/projectColumn.tsx
+++ b/src/components/projectColumn.tsx
@@ -21,11 +21,12 @@ const styles = {
 };
 
 interface ProjectColumnProps {
+    head: number;
     changeHead: (newHead: number) => any;
 }
 
 export class ProjectColumn extends React.Component<ProjectColumnProps, {error: any, isLoaded: boolean, projects: SubTask[] }> {
-
+    head: number;
     constructor(props: ProjectColumnProps) {
         super(props);
 
@@ -35,10 +36,19 @@ export class ProjectColumn extends React.Component<ProjectColumnProps, {error: a
             projects: [],
         };
 
+        this.head = this.props.head;
     }
 
     componentDidMount() {
+        this.head = this.props.head;
         this.getProjects();
+    }
+
+    componentDidUpdate() {
+        if(this.props.head !== this.head) {
+            this.head = this.props.head;
+            this.getProjects();
+        }
     }
 
     // If/when the project list needs to be updated to reflect a database

--- a/src/components/projectColumn.tsx
+++ b/src/components/projectColumn.tsx
@@ -6,6 +6,7 @@ import Col from 'react-bootstrap/Col';
 import { ProjectButton } from "./newProjectButton";
 import { SubTaskButton } from "./subTaskButton";
 import { SubTask } from "./subtaskType";
+import ApplicationConfig from './applicationConfig';
 
 const styles = {
     box: {
@@ -44,7 +45,7 @@ export class ProjectColumn extends React.Component<ProjectColumnProps, {error: a
     // change, a componentDidUpdate() function will need to be added so that
     // the query can be re-run
     getProjects = () => {
-        fetch("https://tasktabs-backend.herokuapp.com/api/projects")
+        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/projects`)
         .then(res => res.json())
         .then(
             (result) => {
@@ -81,7 +82,7 @@ export class ProjectColumn extends React.Component<ProjectColumnProps, {error: a
             return (
                 <Container>
                     <Col style={styles.box} >
-                        <ProjectButton />
+                        <ProjectButton changeHead={this.props.changeHead}/>
                         {projects.map((task) => {
                             return <SubTaskButton name={task.title} percentage={task.progress} key={task._id} changeHead={this.props.changeHead} taskHead={task._id}></SubTaskButton>;
                         })}

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -55,11 +55,13 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
         .then(res => res.json())
         .then(
           (result) => {
-            this.setState({
-              isLoaded: true,
-              task: result,
-              head: result._id
-            });
+            if(result) {
+              this.setState({
+                isLoaded: true,
+                task: result,
+                head: result._id
+              });
+            }
           },
           // Note: it's important to handle errors here
           // instead of a catch() block so that we don't swallow
@@ -117,6 +119,7 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
       );
     }
   }
+
   private changeHead = (newHead: number) => {
     const previousHead = this.state.head;
     if (newHead !== previousHead) {

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -54,37 +54,40 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
   // This is needed because if the head was recently inserted, the fetch will
   // likely return null as the database will not have caught up yet.
   makeProjectQuery = (numTries: number) => {
+    let timeout;
     if (numTries == 0) {
       this.setState({
         isLoaded: false,
         error: true
       });
-      
+      clearTimeout(timeout);
     } else {
-      fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${this.props.projectID}`)
-      .then(res => res.json())
-      .then(
-        (result) => {
-          if (result) {
+      timeout = setTimeout(() => {
+        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${this.props.projectID}`)
+        .then(res => res.json())
+        .then(
+          (result) => {
+            if (result) {
+              this.setState({
+                isLoaded: true,
+                task: result,
+                head: result._id
+              });
+            } else {
+              this.makeProjectQuery(numTries - 1);
+            }
+          },
+          // Note: it's important to handle errors here
+          // instead of a catch() block so that we don't swallow
+          // exceptions from actual bugs in components.
+          (error) => {
             this.setState({
               isLoaded: true,
-              task: result,
-              head: result._id
+              error
             });
-          } else {
-            this.makeProjectQuery(numTries - 1)
           }
-        },
-        // Note: it's important to handle errors here
-        // instead of a catch() block so that we don't swallow
-        // exceptions from actual bugs in components.
-        (error) => {
-          this.setState({
-            isLoaded: true,
-            error
-          });
-        }
-      );
+        );
+        }, 1000);
     }
   }
 

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -120,7 +120,7 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
       return (
         <Container fluid style={styles.box}>
           <Row noGutters={true}>
-            <Col sm="3"><ProjectColumn changeHead={this.changeHead} /></Col>
+            <Col sm="3"><ProjectColumn head={head} changeHead={this.changeHead} /></Col>
             <Col sm="6"><TaskView
               name={task.title}
               completion={task.progress}

--- a/src/components/subTaskColumn.tsx
+++ b/src/components/subTaskColumn.tsx
@@ -8,6 +8,7 @@ import Button from 'react-bootstrap/Button';
 import { SubTask } from "./subtaskType";
 import { SubTaskButton } from './subTaskButton';
 import ApplicationConfig from './applicationConfig';
+import { NewSubTaskButton } from "./newSubTaskButton";
 
 const styles = {
     button: {
@@ -97,7 +98,7 @@ export class SubTaskColumn extends React.Component<SubTaskColumnProps, { error: 
                 <Container>
                     <Col style={styles.box}>
                         <Row noGutters={true}>
-                            <Button style={styles.button} size="lg" variant="outline-primary"> + New Task </Button>
+                            <NewSubTaskButton head={this.props.head}changeHead={this.props.changeHead} />
                         </Row>
                         <Row noGutters={true}>
                             {subTasks.map((task) => {

--- a/src/components/subTaskColumn.tsx
+++ b/src/components/subTaskColumn.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Button from 'react-bootstrap/Button';
 
 import { SubTask } from "./subtaskType";
 import { SubTaskButton } from './subTaskButton';
@@ -34,7 +33,7 @@ interface SubTaskColumnProps {
 
 // This creates the entire right-hand column of project page. It handles the button that creates a new task,
 // and hands down a single element of a subtask array to create subtask buttons one by one.
-export class SubTaskColumn extends React.Component<SubTaskColumnProps, { error: any, isLoaded: boolean, subTasks: SubTask[]}>{
+export class SubTaskColumn extends React.Component<SubTaskColumnProps, { error: any, isLoaded: boolean, subTasks: SubTask[] }>{
     head: number;
     constructor(props: SubTaskColumnProps) {
         super(props);
@@ -50,36 +49,51 @@ export class SubTaskColumn extends React.Component<SubTaskColumnProps, { error: 
 
     componentDidMount() {
         this.head = this.props.head;
-        this.getSubtasks();
+        this.makeSubTaskQuery(5);
     }
 
     componentDidUpdate() {
-        if(this.props.head !== this.head) {
+        if (this.props.head !== this.head) {
             this.head = this.props.head;
-            this.getSubtasks();
+            this.setState({ isLoaded: false });
+            this.makeSubTaskQuery(5);
         }
     }
 
-    getSubtasks = () => {
-        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/subtasks/${this.props.head}`)
-        .then(res => res.json())
-        .then(
-            (result) => {
-                this.setState({
-                    isLoaded: true,
-                    subTasks: result,
-                });
-            },
-            // Note: it's important to handle errors here
-            // instead of a catch() block so that we don't swallow
-            // exceptions from actual bugs in components.
-            (error) => {
-                this.setState({
-                    isLoaded: true,
-                    error
-                });
+    // This will attempt to fetch from the database a given number of times.
+    // This is needed because if the head was recently inserted, the fetch will
+    // likely return null as the database will not have caught up yet.
+    makeSubTaskQuery = (numTries: number) => {
+        if (numTries == 0) {
+            this.setState({
+                isLoaded: false,
+                error: true
+            });
+        } else {
+                fetch(`${ApplicationConfig.api.staging.baseUrl}/api/subtasks/${this.props.head}`)
+                .then(res => res.json())
+                .then(
+                    (result) => {
+                        if (result) {
+                            this.setState({
+                                isLoaded: true,
+                                subTasks: result,
+                            });
+                        } else {
+                            this.makeSubTaskQuery(numTries - 1);
+                        }
+                    },
+                    // Note: it's important to handle errors here
+                    // instead of a catch() block so that we don't swallow
+                    // exceptions from actual bugs in components.
+                    (error) => {
+                        this.setState({
+                            isLoaded: true,
+                            error
+                        });
+                    }
+                );
             }
-        );
     }
 
     render() {
@@ -98,7 +112,7 @@ export class SubTaskColumn extends React.Component<SubTaskColumnProps, { error: 
                 <Container>
                     <Col style={styles.box}>
                         <Row noGutters={true}>
-                            <NewSubTaskButton head={this.props.head}changeHead={this.props.changeHead} />
+                            <NewSubTaskButton head={this.props.head} changeHead={this.props.changeHead} />
                         </Row>
                         <Row noGutters={true}>
                             {subTasks.map((task) => {


### PR DESCRIPTION
This PR adds functionality to the new project and new task buttons. They're a bit confusing because we don't have history yet, but they work as intended. When you create a new task or project, the center view is set to the new creation. When editing and saving is implemented, you'll be able to do that in the center view. You might notice that the columns flash after you click a task/project and that's because they are loading, but possess no loading or error state yet. 
![image](https://user-images.githubusercontent.com/48894331/78720120-1ac92f80-78f3-11ea-9695-a2456ab9a1b3.png)
