### PR TITLE
Create Task History

### DIFF
--- a/src/components/historyButton.tsx
+++ b/src/components/historyButton.tsx
@@ -1,20 +1,6 @@
 import * as React from 'react';
 
-import Button from 'react-bootstrap/Button';
-
-const styles = {
-    button: {
-        height: 25,
-        fontSize: 16,
-        padding: 0,
-        margin: 0
-    }
-};
-
-interface ProjectHistory {
-    id: number,
-    name: string
-};
+import Breadcrumb from 'react-bootstrap/Breadcrumb';
 
 interface HistoryButtonProps {
     id: number,
@@ -39,10 +25,18 @@ export class HistoryButton extends React.Component<HistoryButtonProps>{
     }
 
     render() {
-        return (
-            <Button variant={this.props.id === this.props.currentHead ? "success" : "secondary"} onClick={this.onButtonClick}>
-                {this.props.name}
-            </Button>
-        );
+        if (this.props.id == this.props.currentHead) {
+            return (
+                <Breadcrumb.Item active>
+                    {this.props.name}
+                </Breadcrumb.Item>
+            );
+        } else {
+            return (
+                <Breadcrumb.Item onClick={this.onButtonClick}>
+                    {this.props.name}
+                </Breadcrumb.Item>
+            );
+        }
     }
 };

--- a/src/components/historyButton.tsx
+++ b/src/components/historyButton.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import Button from 'react-bootstrap/Button';
+
+const styles = {
+    button: {
+        height: 25,
+        fontSize: 16,
+        padding: 0,
+        margin: 0
+    }
+};
+
+interface ProjectHistory {
+	id: number,
+	name: string
+};
+
+interface HistoryButtonProps {
+    id: number,
+    name: string
+    changeHead: (newHead: number) => any;
+}
+
+// This is a single SubTask button. They live in the right hand side of the project page.
+// This reuses the progress bar for the background of the button.
+export class HistoryButton extends React.Component<HistoryButtonProps>{
+    name: string;
+    displayedName: string;
+
+    constructor(props: HistoryButtonProps) {
+        super(props);
+
+    }
+
+    onButtonClick = () => {
+        this.props.changeHead(this.props.id);
+    }
+
+    render() {
+        return (
+        <Button variant="info" onClick={this.onButtonClick}>
+            {this.props.name}
+        </Button>
+        );
+    }
+};

--- a/src/components/historyButton.tsx
+++ b/src/components/historyButton.tsx
@@ -12,14 +12,15 @@ const styles = {
 };
 
 interface ProjectHistory {
-	id: number,
-	name: string
+    id: number,
+    name: string
 };
 
 interface HistoryButtonProps {
     id: number,
     name: string
     changeHead: (newHead: number) => any;
+    currentHead: number;
 }
 
 // This is a single SubTask button. They live in the right hand side of the project page.
@@ -39,9 +40,9 @@ export class HistoryButton extends React.Component<HistoryButtonProps>{
 
     render() {
         return (
-        <Button variant="info" onClick={this.onButtonClick}>
-            {this.props.name}
-        </Button>
+            <Button variant={this.props.id === this.props.currentHead ? "success" : "secondary"} onClick={this.onButtonClick}>
+                {this.props.name}
+            </Button>
         );
     }
 };

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -21,12 +21,13 @@ const styles = {
   button: {
 		height: 20,
 		fontSize: 16
-	}
+	},
 };
 
 const HistoryRow = styled.div`
 	padding: 4px;
 	padding-left: 32px;
+	width: 98%;
 `;
 
 const HistorySpacer = styled.div`
@@ -149,12 +150,12 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 					{history.map((node, index) => {
 						if (index === history.length - 1) {
 							return (
-								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory}/>
+								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head}/>
 							);
 						}
 						return (
 							<>
-								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory}/>
+								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head}/>
 								<HistorySpacer> -> </HistorySpacer>
 							</>
 						);
@@ -237,7 +238,7 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 						// This deletes the history after the previous head, and adds the new head to the end of the list.
 						// Reason being that if you have pre-existing history and you go back in history and click a task button that was
 						// not in the history previous, the entire history after the previous head must be erased.
-						else if (!isNewHeadHistoryTail){
+						else if (!isNewHeadHistoryTail) {
 							let headDiscovered = false;
 							let history = this.state.history;
 

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -11,6 +11,7 @@ import { SubTask } from "./subtaskType";
 import { TaskView } from "./taskView";
 import ApplicationConfig from './applicationConfig';
 import { HistoryButton } from "./historyButton";
+import Breadcrumb from "react-bootstrap/Breadcrumb";
 
 const styles = {
 	box: {
@@ -24,19 +25,9 @@ const styles = {
 	},
 };
 
-const HistoryWrapper = styled.div`
-	display: flex;
-	flex-direction: row;
-`;
-
 const HistoryRow = styled.div`
 	padding: 4px;
-	padding-left: 32px;
-	width: 98%;
-`;
-
-const HistorySpacer = styled.div`
-	padding: 4px;
+	padding-left: 16px;
 `;
 
 interface IUser {
@@ -151,21 +142,13 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 		} else {
 
 			let historyComponent =
-				<Row >
-					{history.map((node, index) => {
-						if (index === history.length - 1) {
-							return (
-								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head} />
-							);
-						}
+				<Breadcrumb>
+					{history.map(node => {
 						return (
-							<HistoryWrapper key={node.id}>
-								<HistoryButton id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head} />
-								<HistorySpacer> -> </HistorySpacer>
-							</HistoryWrapper>
+								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head} />
 						);
 					})}
-				</Row>;
+				</Breadcrumb>;
 
 			// prevent date from being invalid, else everythign crashes
 			let deadline;

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -18,11 +18,16 @@ const styles = {
 		paddingRight: 0,
 		minWidth: 1300
 	},
-  button: {
+	button: {
 		height: 20,
 		fontSize: 16
 	},
 };
+
+const HistoryWrapper = styled.div`
+	display: flex;
+	flex-direction: row;
+`;
 
 const HistoryRow = styled.div`
 	padding: 4px;
@@ -150,14 +155,14 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 					{history.map((node, index) => {
 						if (index === history.length - 1) {
 							return (
-								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head}/>
+								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head} />
 							);
 						}
 						return (
-							<>
-								<HistoryButton key={node.id} id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head}/>
+							<HistoryWrapper key={node.id}>
+								<HistoryButton id={node.id} name={node.name} changeHead={this.changeHeadFromHistory} currentHead={head} />
 								<HistorySpacer> -> </HistorySpacer>
-							</>
+							</HistoryWrapper>
 						);
 					})}
 				</Row>;
@@ -241,19 +246,29 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 						else if (!isNewHeadHistoryTail) {
 							let headDiscovered = false;
 							let history = this.state.history;
+							let isNewHeadInHistory = false;
 
-							// destory the end of the history until the head is discovered
-							while(!headDiscovered && history.length !== 0) {
-								if (history[history.length - 1].id !== previousHead) {
-									history.pop();
-								} else {
-									headDiscovered = true;
+							// Check if the history is still correct, even though a task button was clicked
+							for (let i = 0; i < history.length; i++) {
+								if (history[i].id === newHead) {
+									isNewHeadInHistory = true;
 								}
 							}
-							let taskHistoryNode: ProjectHistory;
-							taskHistoryNode = { id: result._id, name: result.title };
+							if (!isNewHeadInHistory) {
+								// destory the end of the history until the head is discovered
+								while (!headDiscovered && history.length !== 0) {
+									if (history[history.length - 1].id !== previousHead) {
+										history.pop();
+									} else {
+										headDiscovered = true;
+									}
+								}
+								let taskHistoryNode: ProjectHistory;
+								taskHistoryNode = { id: result._id, name: result.title };
 
-							history.push(taskHistoryNode);
+								history.push(taskHistoryNode);
+							}
+
 							this.setState({
 								isLoaded: true,
 								task: result,

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -234,36 +234,36 @@ export class ProjectPage extends React.Component<ProjectPageProps, { error: any,
 							});
 
 						}
-						// if the caller is a task and not a project, append to the history.
+						// This deletes the history after the previous head, and adds the new head to the end of the list.
+						// Reason being that if you have pre-existing history and you go back in history and click a task button that was
+						// not in the history previous, the entire history after the previous head must be erased.
 						else if (!isNewHeadHistoryTail){
-							let taskHistoryNode: ProjectHistory;
-							taskHistoryNode = { id: result._id, name: result.title };
-
-							this.setState({
-								isLoaded: true,
-								task: result,
-								history: this.state.history.concat([taskHistoryNode])
-							});
-						}
-
-						// this deletes the history after the new head, used when clicking on a history button.
-						else {
 							let headDiscovered = false;
 							let history = this.state.history;
 
 							// destory the end of the history until the head is discovered
 							while(!headDiscovered && history.length !== 0) {
-								if (history[history.length - 1].id !== newHead) {
+								if (history[history.length - 1].id !== previousHead) {
 									history.pop();
 								} else {
 									headDiscovered = true;
 								}
 							}
+							let taskHistoryNode: ProjectHistory;
+							taskHistoryNode = { id: result._id, name: result.title };
 
+							history.push(taskHistoryNode);
 							this.setState({
 								isLoaded: true,
 								task: result,
 								history: history
+							});
+						}
+						// If the user clicked a history button, no history changes need to be made.
+						else {
+							this.setState({
+								isLoaded: true,
+								task: result,
 							});
 						}
 					},

--- a/src/components/projectPage.tsx
+++ b/src/components/projectPage.tsx
@@ -12,161 +12,212 @@ import ApplicationConfig from './applicationConfig';
 import { number } from "prop-types";
 
 const styles = {
-  box: {
-    paddingLeft: 0,
-    paddingRight: 0,
-    minWidth: 1300
-  }
+	box: {
+		paddingLeft: 0,
+		paddingRight: 0,
+		minWidth: 1300
+	}
 };
 
 interface IUser {
-  id: number;
-  name: string;
+	id: number;
+	name: string;
 }
 
 const testOwner: IUser = { id: 0, name: "Super Steve" };
 
 const testSharedWith: IUser[] = [
-  { id: 1, name: "Little Steve" },
-  { id: 2, name: "Tiny Steve" },
+	{ id: 1, name: "Little Steve" },
+	{ id: 2, name: "Tiny Steve" },
 ];
 
+interface ProjectHistory {
+	id: number,
+	name: string
+};
+
 interface ProjectPageProps {
-  projectID: number;
+	projectID: number;
 }
 
 // ProjectPage contains the entire application past the Google oauth. This should include the left and right sidebars
 // task view, settings user info, etc.
-export class ProjectPage extends React.Component<ProjectPageProps, { error: any, isLoaded: boolean, task: SubTask, head: number }>{
+export class ProjectPage extends React.Component<ProjectPageProps, { error: any, isLoaded: boolean, task: SubTask, head: number, history: ProjectHistory[] }>{
 
-  constructor(props: ProjectPageProps) {
-    super(props);
+	constructor(props: ProjectPageProps) {
+		super(props);
 
-    this.state = {
-      error: null,
-      isLoaded: false,
-      task: null,
-      head: undefined,
-    };
-  }
+		this.state = {
+			error: null,
+			isLoaded: false,
+			task: null,
+			head: undefined,
+			history: [],
+		};
+	}
 
-  // This will attempt to fetch from the database a given number of times.
-  // This is needed because if the head was recently inserted, the fetch will
-  // likely return null as the database will not have caught up yet.
-  makeProjectQuery = (numTries: number) => {
-    let timeout;
-    if (numTries == 0) {
-      this.setState({
-        isLoaded: false,
-        error: true
-      });
-      clearTimeout(timeout);
-    } else {
-      timeout = setTimeout(() => {
-        fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${this.props.projectID}`)
-        .then(res => res.json())
-        .then(
-          (result) => {
-            if (result) {
-              this.setState({
-                isLoaded: true,
-                task: result,
-                head: result._id
-              });
-            } else {
-              this.makeProjectQuery(numTries - 1);
-            }
-          },
-          // Note: it's important to handle errors here
-          // instead of a catch() block so that we don't swallow
-          // exceptions from actual bugs in components.
-          (error) => {
-            this.setState({
-              isLoaded: true,
-              error
-            });
-          }
-        );
-        }, 1000);
-    }
-  }
+	// This will attempt to fetch from the database a given number of times.
+	// This is needed because if the head was recently inserted, the fetch will
+	// likely return null as the database will not have caught up yet.
+	makeProjectQuery = (numTries: number) => {
+		let timeout;
+		if (numTries == 0) {
+			this.setState({
+				isLoaded: false,
+				error: true
+			});
+			clearTimeout(timeout);
+		} else {
+			timeout = setTimeout(() => {
+				fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${this.props.projectID}`)
+					.then(res => res.json())
+					.then(
+						(result) => {
+							if (result) {
 
-  componentDidMount() {
-    // This will attempt to the make the Project Query 5 times before giving up.
-    this.makeProjectQuery(5);
-  }
+								// add the project to the beginning of the history
+								let taskHistoryNode: ProjectHistory;
+								taskHistoryNode = {id: result._id, name: result.title };
+
+								// state should be treated as if it were immutable.
+								// However, concat returns a new array.
+								this.setState({
+									isLoaded: true,
+									task: result,
+									head: result._id,
+									history: this.state.history.concat([taskHistoryNode])
+								});
+
+							} else {
+								this.makeProjectQuery(numTries - 1);
+							}
+						},
+						// Note: it's important to handle errors here
+						// instead of a catch() block so that we don't swallow
+						// exceptions from actual bugs in components.
+						(error) => {
+							this.setState({
+								isLoaded: true,
+								error
+							});
+						}
+					);
+			}, 1000);
+		}
+	}
+
+	componentDidMount() {
+		// This will attempt to the make the Project Query 5 times before giving up.
+		this.makeProjectQuery(5);
+	}
 
 
-  // TODO
-  // assignedTo should probably be a User, not a string. Fine for now with dummy data,
-  // but should be replaced.
-  public render() {
+	// TODO
+	// assignedTo should probably be a User, not a string. Fine for now with dummy data,
+	// but should be replaced.
+	public render() {
 
-    const { error, isLoaded, task, head } = this.state;
-    // TODO Style error and loading screens
+		const { error, isLoaded, task, head } = this.state;
+		// TODO Style error and loading screens
 
-    if (error) {
-      return (
-        <>Error!</>
-      );
-    } else if (!isLoaded) {
-      return (
-        <>Loading...</>
-      );
-    } else {
-      let deadline;
-      if (!!task.deadline) {
-        deadline = new Date(task.deadline);
-      } else {
-        deadline = null;
-      }
-      return (
-        <Container fluid style={styles.box}>
-          <Row noGutters={true}>
-            <Col sm="3"><ProjectColumn head={head} changeHead={this.changeHead} /></Col>
-            <Col sm="6"><TaskView
-              taskID={head}
-			  name={task.title}
-              completion={task.progress}
-              description={task.description}
-              dueDate={deadline}
-              status={task.status}
-              assignee={task.assignedTo}
-              owner={testOwner}
-              sharedUsers={testSharedWith}
-            /></Col>
-            <Col sm="3"><SubTaskColumn head={head} changeHead={this.changeHead}></SubTaskColumn></Col>
-          </Row>
-        </Container>
-      );
-    }
-  }
+		if (error) {
+			return (
+				<>Error!</>
+			);
+		} else if (!isLoaded) {
+			return (
+				<>Loading...</>
+			);
+		} else {
+			let deadline;
+			if (!!task.deadline) {
+				deadline = new Date(task.deadline);
+			} else {
+				deadline = null;
+			}
+			return (
+				<Container fluid style={styles.box}>
+					<Row noGutters={true}>
+						<Col sm="3"><ProjectColumn head={head} changeHead={this.changeHeadFromProject} /></Col>
+						<Col sm="6"><TaskView
+							taskID={head}
+							name={task.title}
+							completion={task.progress}
+							description={task.description}
+							dueDate={deadline}
+							status={task.status}
+							assignee={task.assignedTo}
+							owner={testOwner}
+							sharedUsers={testSharedWith}
+						/></Col>
+						<Col sm="3"><SubTaskColumn head={head} changeHead={this.changeHeadFromTask}></SubTaskColumn></Col>
+					</Row>
+				</Container>
+			);
+		}
+	}
 
-  private changeHead = (newHead: number) => {
-    const previousHead = this.state.head;
-    if (newHead !== previousHead) {
-      this.setState(() => {
-        return { head: newHead };
-      })
-      fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${newHead}`)
-        .then(res => res.json())
-        .then(
-          (result) => {
-            this.setState({
-              isLoaded: true,
-              task: result,
-            });
-          },
-          // Note: it's important to handle errors here
-          // instead of a catch() block so that we don't swallow
-          // exceptions from actual bugs in components.
-          (error) => {
-            this.setState({
-              isLoaded: true,
-              error
-            });
-          }
-        );
-    }
-  }
+	private changeHeadFromTask = (newHead: number) =>{
+		this.changeHead(newHead, false);
+	}
+
+	private changeHeadFromProject = (newHead: number) =>{
+		this.changeHead(newHead, true);
+	}
+
+	private changeHead = (newHead: number, isProject: boolean) => {
+		const previousHead = this.state.head;
+		if (newHead !== previousHead) {
+
+			this.setState(() => {
+				return { head: newHead };
+			})
+
+			fetch(`${ApplicationConfig.api.staging.baseUrl}/api/tasks/${newHead}`)
+				.then(res => res.json())
+				.then(
+					(result) => {
+
+						// Update History
+						if (isProject) {
+							let newHistory: ProjectHistory[] = [];
+
+							// create new node
+							let taskHistoryNode: ProjectHistory;
+							taskHistoryNode = {id: result._id, name: result.title };
+
+							newHistory.push(taskHistoryNode);
+
+							// set new task
+							this.setState({
+								isLoaded: true,
+								task: result,
+								history: newHistory
+							});
+
+						} 
+						// if the caller is a task and not a project, append to the history.
+						else {
+							let taskHistoryNode: ProjectHistory;
+							taskHistoryNode = {id: result._id, name: result.title };
+
+							this.setState({
+								isLoaded: true,
+								task: result,
+								history: this.state.history.concat([taskHistoryNode])
+							});
+						}
+					},
+					// Note: it's important to handle errors here
+					// instead of a catch() block so that we don't swallow
+					// exceptions from actual bugs in components.
+					(error) => {
+						this.setState({
+							isLoaded: true,
+							error
+						});
+					}
+				);
+		}
+	}
 };


### PR DESCRIPTION
The history breadcrumb trail has arrived and unfortunately it's not in the navbar as hoped. Turns out putting the history in the navbar may be much more effort than it's worth. Anyway, the history trail is made up of buttons, all of which can be clicked, redirecting you to the respective task. The current task is highlighted to make clear where you are in the history.

Please suggest styling desires, I'm certainly open to suggestions and this is the time to change it.

![image](https://user-images.githubusercontent.com/48894331/79195468-533da180-7dfc-11ea-9011-3a511d979f57.png)
